### PR TITLE
Update plotting.py

### DIFF
--- a/brian/plotting.py
+++ b/brian/plotting.py
@@ -221,6 +221,7 @@ def raster_plot(*monitors, **additionalplotoptions):
                         line.set_ydata(sn)
                     if myopts['redraw']:
                         pylab.draw()
+                        pylab.pause(0.001) # prevents the NotImplementedError
                         pylab.get_current_fig_manager().canvas.flush_events()
             monitors[0].contained_objects.append(refresh_raster_plot)
 


### PR DESCRIPTION
This fix for the following error:
site-packages/brian/plotting.py in refresh_raster_plot(clk)
    222                     if myopts['redraw']:
    223                         pylab.draw()
--> 224                         pylab.get_current_fig_manager().canvas.flush_events()
    225             monitors[0].contained_objects.append(refresh_raster_plot)
    226 

site-packages/matplotlib/backend_bases.pyc in flush_events(self)
   2408         backends with GUIs.
   2409         """
-> 2410         raise NotImplementedError
   2411 
   2412     def start_event_loop(self, timeout):

NotImplementedError:
 
Fix proposed here:
https://github.com/matplotlib/matplotlib/issues/7759/